### PR TITLE
Degrade to imageless upload when backlog image is missing

### DIFF
--- a/payload.py
+++ b/payload.py
@@ -39,6 +39,20 @@ def uploadPayload(payloadData, log, secrets, fromFile, maxRetries=3):
 
     image = payloadData.get("image")
 
+    # A saved/backlogged payload may reference an image that has since been
+    # deleted from disk (e.g. by image cleanup). Trying to open it raises
+    # [Errno 2] and, treated as a failure, permanently blocks the backlog
+    # drain. Degrade to an imageless upload so the measurement still lands and
+    # the poison entry clears from the backlog.
+    if image is not None:
+        currDirectory = os.path.dirname(os.path.abspath(__file__))
+        filePath = os.path.join(currDirectory, image)
+        if not os.path.exists(filePath):
+            log.warning(
+                f"Image file no longer exists, uploading payload without image: {filePath}"
+            )
+            image = None
+
     if image is None:
         log.warning("No image available, uploading payload without image.")
         uploaded = False


### PR DESCRIPTION
## Problem
A saved payload whose image file was later deleted from disk caused `uploadPayload` to fail on `open()` with `[Errno 2]`. `uploadSavedPayloads` treated that permanent failure like a transient network error and `break`d out of the drain loop, leaving the orphaned entry in `payloadData.txt` **forever** — it re-failed and re-logged the error every cycle and blocked every payload queued behind it.

Observed in the field:
```
ERROR - Error opening image file: [Errno 2] No such file or directory: '.../0000000030604cb8_2026-07-09_12-10-52.jpg'
ERROR - Some payloads could not be uploaded, saved in the file.
```

## Fix
Detect the missing image file up front and degrade to an **imageless upload** (a path the code already supports for camera failures), so the measurement still lands and the poison entry clears from the backlog.

## Testing
- `python -m py_compile payload.py` passes.
- Self-heals on the next successful upload cycle once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)