### PR TITLE
Disable internal radio outright when external antenna is present

### DIFF
--- a/tools/dw_startup.sh
+++ b/tools/dw_startup.sh
@@ -9,19 +9,38 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 /usr/bin/tvservice -o >/dev/null 2>&1 || true
 /usr/sbin/rfkill unblock wifi || true
 
-# --- WiFi: external antenna (wlan1) is the link; wlan0 is a cold standby ------
+# --- WiFi: external antenna only; the internal radio is disabled outright -----
 # This device is client-only and must NEVER act as an access point.
 #
-# wlan0 (internal radio) is NOT left running. With both radios associated the
-# unit grabs two hotspot slots and the kernel may route via wlan0; once the
-# enclosure is submerged wlan0's antenna is dead, so traffic pinned to it (or to
-# its IP) black-holes -- which is why the unit went silent and SSH failed
-# underwater even though wlan1 was still connected. So wlan1 autoconnects and we
-# only fall back to wlan0 if wlan1 cannot reach the internet (e.g. bench/setup).
+# The internal radio's antenna is dead once the enclosure is submerged, and any
+# time it is associated the kernel may pin routes (or inbound SSH) to it, which
+# black-holes underwater. Earlier revisions kept it as a fallback behind an
+# internet check, but that check raced the external link at boot (and could be
+# satisfied via the internal radio's own route), so one bad boot left the
+# internal radio up for the whole deployment. The rule is now unconditional:
+# if the external USB adapter is present, the internal radio is shut down and
+# marked unmanaged so NetworkManager cannot bring it back. The internal radio
+# is only used when the USB adapter is missing altogether (bench recovery with
+# the enclosure open).
+#
+# Interfaces are identified by bus, not name: the onboard radio is SDIO, the
+# antenna adapter is USB. wlan0/wlan1 assignment can vary, and disabling the
+# onboard radio via dtoverlay=disable-wifi renames the USB adapter to wlan0,
+# so names are never hard-coded.
 #
 # Credentials come from a non-committed file so they stay out of git; see
 # wifi.conf.example.
 WIFI_CONF="${DW_WIFI_CONF:-/home/rpi/dw/wifi.conf}"
+
+INT_IF="" EXT_IF=""
+for path in /sys/class/net/wlan*; do
+    [ -e "$path/device" ] || continue
+    if readlink -f "$path/device" | grep -q usb; then
+        EXT_IF="${path##*/}"
+    else
+        INT_IF="${path##*/}"
+    fi
+done
 
 ensure_wifi_profile () {
     # $1=connection name  $2=interface  $3=autoconnect (yes|no)
@@ -41,13 +60,15 @@ ensure_wifi_profile () {
     fi
 }
 
-wlan1_has_internet () {
-    # Test connectivity *via wlan1 specifically* using its own source IP, so we
-    # don't need root to bind to the interface and can't be fooled by wlan0.
-    local ip
-    ip="$(nmcli -g IP4.ADDRESS device show wlan1 2>/dev/null | head -n1 | cut -d/ -f1)"
-    [ -n "$ip" ] || return 1
-    ping -I "$ip" -c1 -W2 8.8.8.8 >/dev/null 2>&1
+disable_other_wifi_profiles () {
+    # Any wifi profile other than $1 (e.g. the imager's "preconfigured" one is
+    # not bound to an interface) could still autoconnect the internal radio.
+    local keep="$1" con
+    nmcli -t -f NAME,TYPE connection show 2>/dev/null |
+        awk -F: -v keep="$keep" '$2 ~ /wireless/ && $1 != keep {print $1}' |
+        while IFS= read -r con; do
+            nmcli connection modify "$con" connection.autoconnect no || true
+        done || true
 }
 
 if [ -r "$WIFI_CONF" ]; then
@@ -55,39 +76,36 @@ if [ -r "$WIFI_CONF" ]; then
     . "$WIFI_CONF"
 fi
 
-if [ -n "${WIFI_SSID:-}" ] && [ -n "${WIFI_PSK:-}" ]; then
-    # wlan1 autoconnects; wlan0 stays a manual, powered-down standby.
-    ensure_wifi_profile wifi-ext wlan1 yes
-    ensure_wifi_profile wifi-int wlan0 no
+if [ -z "${WIFI_SSID:-}" ] || [ -z "${WIFI_PSK:-}" ]; then
+    echo "dw_startup: $WIFI_CONF missing or WIFI_SSID/WIFI_PSK unset; skipping wifi setup (see wifi.conf.example)" >&2
+elif [ -n "$EXT_IF" ]; then
+    ensure_wifi_profile wifi-ext "$EXT_IF" yes
+    disable_other_wifi_profiles wifi-ext
 
-    /bin/ip link set wlan1 up 2>/dev/null || /usr/sbin/ip link set wlan1 up || true
+    ip link set "$EXT_IF" up 2>/dev/null || true
     # power-save lets the radio sleep between beacons, making the device appear
     # connected but unreachable for inbound SSH/web -- keep it off on our link.
-    /usr/sbin/iw dev wlan1 set power_save off || true
+    iw dev "$EXT_IF" set power_save off || true
+    nmcli connection up wifi-ext >/dev/null 2>&1 || true
 
-    # Give the external antenna up to ~45s to associate and reach the internet.
-    online=0
-    for _ in $(seq 1 15); do
-        if wlan1_has_internet; then online=1; break; fi
-        sleep 3
-    done
-
-    if [ "$online" = 1 ]; then
-        # External antenna is our link -- shut the internal radio fully down so
-        # it can't grab a second slot or hijack the route when submerged.
-        nmcli device disconnect wlan0 >/dev/null 2>&1 || true
-        /bin/ip link set wlan0 down 2>/dev/null || /usr/sbin/ip link set wlan0 down || true
-        echo "dw_startup: wlan1 online; wlan0 disabled" >&2
+    if [ -n "$INT_IF" ]; then
+        nmcli device disconnect "$INT_IF" >/dev/null 2>&1 || true
+        nmcli device set "$INT_IF" managed no >/dev/null 2>&1 || true
+        ip link set "$INT_IF" down 2>/dev/null || true
+        echo "dw_startup: external antenna $EXT_IF is the link; internal radio $INT_IF disabled" >&2
     else
-        # No internet on the external antenna -- fall back to the internal radio
-        # so the device stays reachable for recovery (e.g. on the bench).
-        echo "dw_startup: wlan1 offline after wait; enabling wlan0 fallback" >&2
-        /bin/ip link set wlan0 up 2>/dev/null || /usr/sbin/ip link set wlan0 up || true
-        /usr/sbin/iw dev wlan0 set power_save off || true
-        nmcli connection up wifi-int >/dev/null 2>&1 || true
+        echo "dw_startup: external antenna $EXT_IF is the link; no internal radio present" >&2
     fi
+elif [ -n "$INT_IF" ]; then
+    # No USB adapter at all -- bench recovery on the internal radio so the
+    # device stays reachable with the enclosure open.
+    echo "dw_startup: no external USB adapter found; using internal radio $INT_IF" >&2
+    ensure_wifi_profile wifi-int "$INT_IF" yes
+    ip link set "$INT_IF" up 2>/dev/null || true
+    iw dev "$INT_IF" set power_save off || true
+    nmcli connection up wifi-int >/dev/null 2>&1 || true
 else
-    echo "dw_startup: $WIFI_CONF missing or WIFI_SSID/WIFI_PSK unset; skipping wifi setup (see wifi.conf.example)" >&2
+    echo "dw_startup: no wifi interfaces found" >&2
 fi
 # -----------------------------------------------------------------------------
 

--- a/tools/wifi.conf.example
+++ b/tools/wifi.conf.example
@@ -8,9 +8,10 @@
 # This file is sourced by bash, so use KEY="value" with no spaces around '='.
 # The real wifi.conf is git-ignored — never commit credentials.
 #
-# The same network is joined on both interfaces; dw_startup.sh makes the
-# external antenna (wlan1) the preferred client and the internal radio (wlan0)
-# the backup. To point at a different config path, set DW_WIFI_CONF.
+# dw_startup.sh joins this network on the external USB antenna and disables
+# the internal radio entirely; the internal radio is only used when no USB
+# adapter is plugged in (bench recovery). To point at a different config path,
+# set DW_WIFI_CONF.
 
 WIFI_SSID="YourNetworkName"
 WIFI_PSK="YourNetworkPassword"


### PR DESCRIPTION
## What changed

`tools/dw_startup.sh` no longer keeps the internal radio as an internet-check fallback. The rule is now unconditional:

- **External USB adapter present → it is the only link.** The internal radio is disconnected, marked `managed no` in NetworkManager, and its link taken down.
- **All other NM wifi profiles get `autoconnect no`** (e.g. the Raspberry Pi Imager's "preconfigured" profile, which isn't bound to an interface and could silently re-associate the internal radio at boot).
- **Interfaces are identified by bus, not name** — onboard radio is SDIO, antenna adapter is USB — so `wlan0`/`wlan1` are no longer hard-coded and the script survives `dtoverlay=disable-wifi` renaming the USB adapter to `wlan0`.
- **Bench recovery kept:** if no USB adapter is plugged in at all, the internal radio is used so an open-enclosure device stays reachable. This is a hardware-presence check, not an internet check, so it can't misfire in deployment.

Also updated the stale behavior description in `tools/wifi.conf.example`.

## Why

The previous fallback raced the external link at boot: if wlan1 couldn't reach the internet within ~45s, wlan0 came up and **stayed up for the entire deployment** — nothing ever re-preferred wlan1. Worse, the `ping -I <src-ip>` connectivity test only binds the source address, not the interface, so with both radios on the same network it could be satisfied via wlan0's route and report wlan1 online when it wasn't verified at all. Underwater, the internal antenna is dead, so any traffic pinned to it black-holes — matching the observed symptom of units going silent while submerged.

## Reviewer notes

- Deployed devices run `/home/rpi/dw/dw_startup.sh`, which has drifted from the repo before — after merging, the file must be copied to each device and `dw_monitor.service` restarted.
- `nmcli device set <if> managed no` is runtime-only state; that's fine because the script runs on every boot via `dw_monitor.service`.
- Setting `autoconnect no` on other wifi profiles is a persistent, deliberate change to on-device NM state.
- Syntax-checked with `bash -n`; not yet run on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)