### PR TITLE
Force LF line endings on shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts must keep LF endings even when checked out on Windows.
+# A CRLF shebang (`#!/usr/bin/env bash\r`) makes the kernel look for `bash\r`,
+# which fails with exit 127 -- so dw_startup.sh crash-loops and mainloop.py
+# never starts once the file is copied onto a Pi. Forcing eol=lf here keeps the
+# working tree LF, so an scp straight from a Windows checkout stays valid.
+*.sh text eol=lf


### PR DESCRIPTION
## What

Adds `.gitattributes` with `*.sh text eol=lf`.

## Why

A field device went down today: `dw_startup.sh` was copied from a Windows checkout, which carried **CRLF** line endings. The `\r` on the shebang made the kernel try to exec `bash\r`, which doesn't exist — so `/usr/bin/env` exited **127**, `dw_monitor.service` crash-looped past its restart limit, and `mainloop.py` never started. Fixed live on the device with `sed -i 's/\r$//'`; this prevents recurrence at the source by keeping the working tree LF even on Windows, so an `scp` straight from a checkout stays valid.

## Notes

- Follow-up to #82.
- Scoped to a single file on purpose. `git add --renormalize` also flagged some `.py` files whose blobs carry CRLF; I left those out to keep this focused — worth a separate normalization pass if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)